### PR TITLE
Use different random seed for each msprime sim

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -102,3 +102,7 @@ venv.bak/
 
 # mypy
 .mypy_cache/
+
+# vim
+*.swp
+*.swo

--- a/ReLERNN/simulator.py
+++ b/ReLERNN/simulator.py
@@ -249,9 +249,10 @@ class Simulator(object):
             randomTargetParameter = np.random.uniform(self.priorLowsMu,self.priorHighsMu)
             self.mu[i] = randomTargetParameter
 
-        self.seed=np.random.randint(
-            0, MAX_SEED, size=(numReps,)
-        )
+        if self.seed is None:
+            self.seed=np.repeat(self.seed, numReps)
+        else:
+            self.seed=np.random.randint(0, MAX_SEED, size=(numReps,))
 
         try:
             assert((simulator=='msprime') | (simulator=='SLiM'))

--- a/ReLERNN/simulator.py
+++ b/ReLERNN/simulator.py
@@ -6,6 +6,8 @@ Author: Jared Galloway, Jeff Adrion
 from ReLERNN.imports import *
 from ReLERNN.helpers import *
 
+MAX_SEED = int(2 ** 32 - 1) # maximum allowed seed in msprime
+
 class Simulator(object):
     '''
 
@@ -247,7 +249,9 @@ class Simulator(object):
             randomTargetParameter = np.random.uniform(self.priorLowsMu,self.priorHighsMu)
             self.mu[i] = randomTargetParameter
 
-        self.seed=np.repeat(self.seed,numReps)
+        self.seed=np.random.randint(
+            0, MAX_SEED, size=(numReps,)
+        )
 
         try:
             assert((simulator=='msprime') | (simulator=='SLiM'))


### PR DESCRIPTION
As part of porting the ReLERNN architecture to torch, I've been testing against simulations produced by ReLERNN_SIMULATE, and noticed an issue with independence of simulations. **This is only an issue when the seed is set from the command line.**

- The `info.p` file in each of `train`, `test`, `vali` contains a dict with the parameters used for the simulations, including an array of random seeds, one for each simulation. If the seed is set from the command line, then the arrays all contain a single unique random seed (both within and across train/test/validation sets). The reason is this line: https://github.com/kr-colab/ReLERNN/blob/9eb61ff982955a8b727e95fcdd1a8a78e6318230/ReLERNN/simulator.py#L250
- This single unique seed is used in the msprime invocation for every simulation: https://github.com/kr-colab/ReLERNN/blob/9eb61ff982955a8b727e95fcdd1a8a78e6318230/ReLERNN/simulator.py#L85 Note that if self.seed is `None`, then msprime gets its own seed from CPU noise and everything is fine.
- The simulation parameters (mu and rho) differ across simulations, of course: https://github.com/kr-colab/ReLERNN/blob/9eb61ff982955a8b727e95fcdd1a8a78e6318230/ReLERNN/simulator.py#L240-L248

So when seed is set from the command line, the msprime simulations use the same random seed across all training/testing/validation simulations. Because different parameters are used per simulation, the output haplotypes/positions differ across sims. However, reuse of the same random seed could introduce dependence into simulations-- e.g. they are "less random" than iid simulations from the desired coalescent process.

As a rough check, I replaced the `np.repeat(self.seed, numReps)` bit with `np.random.randint(0, some_large_int, size=(numReps,))` and re-ran the simulation. To reduce other sources of randomness aside from msprime, I didn't use an accessibility mask or phasing error, either with the original or modified code. I then trained the model on each of these datasets without permuting haplotypes for each batch (again, to minimize non-msprime randomness).

Here's what the trained models look like on their respective test sets (rec rates normalised to z-scores):
<p float="left">
<img src="https://github.com/kr-colab/ReLERNN/assets/5767783/025d8030-d46e-4690-8539-c1c2206c9ecd" width="40%">
<img src="https://github.com/kr-colab/ReLERNN/assets/5767783/2e79628b-2781-4adb-9b8d-94a8591d687a" width="40%">
</p>

I tried a few different runs, with the same result. When the msprime seed is re-used, training is much quicker (train_loss gets to 0.02-ish within 30 epochs or so; as opposed to 0.1-ish in 100 epochs when unique seeds are used). 

This is crude test, but does suggest there is dependence introduced by reusing the same random seed across msprime sims, and that the neural network can pick up on it. In practice this may not actually lead to overfitting, because there's lots of additional noise injected via random masking / haplotype shuffling / phasing error / etc -- and these perturbations don't reuse a seed as far as I can tell. But regardless, the current behavior seems undesirable and is easy to fix.